### PR TITLE
fusion chartsをNextjsで動かせるようにしてみる

### DIFF
--- a/src/components/column2DGraph.tsx
+++ b/src/components/column2DGraph.tsx
@@ -1,0 +1,39 @@
+const dataSource = {
+  chart: {
+    caption: 'Countries With Most Oil Reserves [2017-18]',
+    subCaption: 'In MMbbl = One Million barrels',
+    xAxisName: 'Country',
+    yAxisName: 'Reserves (MMbbl)',
+    numberSuffix: 'K',
+    theme: 'fusion',
+  },
+  data: [
+    { label: 'Venezuela', value: '290' },
+    { label: 'Saudi', value: '260' },
+    { label: 'Canada', value: '180' },
+    { label: 'Iran', value: '140' },
+    { label: 'Russia', value: '115' },
+    { label: 'UAE', value: '100' },
+    { label: 'US', value: '30' },
+    { label: 'China', value: '30' },
+  ],
+}
+
+const chartConfigs = {
+  type: 'column2d',
+  width: 650,
+  height: 400,
+  dataFormat: 'json',
+  dataSource: dataSource,
+}
+
+export default function NextFC() {
+  const FusionCharts = require('fusioncharts')
+  const Column2D = require('fusioncharts/fusioncharts.charts')
+  const FusionTheme = require('fusioncharts/themes/fusioncharts.theme.fusion.js')
+  const { default: ReactFC } = require('react-fusioncharts')
+
+  ReactFC.fcRoot(FusionCharts, Column2D, FusionTheme)
+
+  return <ReactFC {...chartConfigs} />
+}

--- a/src/components/column2DGraph.tsx
+++ b/src/components/column2DGraph.tsx
@@ -1,3 +1,8 @@
+import FusionCharts from 'fusioncharts'
+import Column2D from 'fusioncharts/fusioncharts.charts'
+import FusionTheme from 'fusioncharts/themes/fusioncharts.theme.fusion.js'
+import ReactFusionCharts from 'react-fusioncharts'
+
 const dataSource = {
   chart: {
     caption: 'Countries With Most Oil Reserves [2017-18]',
@@ -27,13 +32,8 @@ const chartConfigs = {
   dataSource: dataSource,
 }
 
-export default function NextFC() {
-  const FusionCharts = require('fusioncharts')
-  const Column2D = require('fusioncharts/fusioncharts.charts')
-  const FusionTheme = require('fusioncharts/themes/fusioncharts.theme.fusion.js')
-  const { default: ReactFC } = require('react-fusioncharts')
+export default function Column2DGraph() {
+  ReactFusionCharts.fcRoot(FusionCharts, Column2D, FusionTheme)
 
-  ReactFC.fcRoot(FusionCharts, Column2D, FusionTheme)
-
-  return <ReactFC {...chartConfigs} />
+  return <ReactFusionCharts {...chartConfigs} />
 }

--- a/src/components/column2DGraph.tsx
+++ b/src/components/column2DGraph.tsx
@@ -1,6 +1,7 @@
 import FusionCharts from 'fusioncharts'
 import Column2D from 'fusioncharts/fusioncharts.charts'
 import FusionTheme from 'fusioncharts/themes/fusioncharts.theme.fusion.js'
+import ExcelExport from 'fusioncharts/fusioncharts.excelexport'
 import ReactFusionCharts from 'react-fusioncharts'
 
 const dataSource = {
@@ -11,6 +12,8 @@ const dataSource = {
     yAxisName: 'Reserves (MMbbl)',
     numberSuffix: 'K',
     theme: 'fusion',
+    exportEnabled: 1,
+    exportAtClientSide: 1,
   },
   data: [
     { label: 'Venezuela', value: '290' },
@@ -33,7 +36,7 @@ const chartConfigs = {
 }
 
 export default function Column2DGraph() {
-  ReactFusionCharts.fcRoot(FusionCharts, Column2D, FusionTheme)
+  ReactFusionCharts.fcRoot(FusionCharts, Column2D, FusionTheme, ExcelExport)
 
   return <ReactFusionCharts {...chartConfigs} />
 }

--- a/src/components/timeSeries.tsx
+++ b/src/components/timeSeries.tsx
@@ -7,9 +7,10 @@ import FusionCharts from 'fusioncharts'
 // Step 3 - Including the fusiontime file
 import TimeSeries from 'fusioncharts/fusioncharts.timeseries'
 import ReactFC from 'react-fusioncharts'
+import ExcelExport from 'fusioncharts/fusioncharts.excelexport'
 
 // Step 4 - Adding the chart as dependency to the core fusioncharts
-ReactFC.fcRoot(FusionCharts, TimeSeries)
+ReactFC.fcRoot(FusionCharts, TimeSeries, ExcelExport)
 
 // Step 5 - Creating the JSON object to store the chart configurations
 const dataFetch = () =>
@@ -24,9 +25,13 @@ const schemaFetch = () =>
 const graphConfig = {
   type: 'timeseries',
   renderAt: 'container',
-  width: '600',
-  height: '400',
+  width: 650,
+  height: 400,
   dataSource: {
+    chart: {
+      exportEnabled: 1,
+      exportAtClientSide: 1,
+    },
     caption: { text: 'Online Sales of a SuperStore in the US' },
     data: {},
     yAxis: [

--- a/src/components/timeSeries.tsx
+++ b/src/components/timeSeries.tsx
@@ -1,0 +1,72 @@
+// Step 1 - Including react
+import React, { useEffect, useState } from 'react'
+
+// Step 2 - Including the react-fusioncharts component
+import FusionCharts from 'fusioncharts'
+
+// Step 3 - Including the fusiontime file
+import TimeSeries from 'fusioncharts/fusioncharts.timeseries'
+import ReactFC from 'react-fusioncharts'
+
+// Step 4 - Adding the chart as dependency to the core fusioncharts
+ReactFC.fcRoot(FusionCharts, TimeSeries)
+
+// Step 5 - Creating the JSON object to store the chart configurations
+const dataFetch = () =>
+  fetch(
+    'https://raw.githubusercontent.com/fusioncharts/dev_centre_docs/master/assets/datasources/fusiontime/examples/online-sales-single-series/data.json',
+  ).then((res) => res.json())
+const schemaFetch = () =>
+  fetch(
+    'https://raw.githubusercontent.com/fusioncharts/dev_centre_docs/master/assets/datasources/fusiontime/examples/online-sales-single-series/schema.json',
+  ).then((res) => res.json())
+
+const graphConfig = {
+  type: 'timeseries',
+  renderAt: 'container',
+  width: '600',
+  height: '400',
+  dataSource: {
+    caption: { text: 'Online Sales of a SuperStore in the US' },
+    data: {},
+    yAxis: [
+      {
+        plot: [
+          {
+            value: 'Sales ($)',
+          },
+        ],
+      },
+    ],
+  },
+}
+
+export default function TimeGraph() {
+  const [timeSeriesDs, setTimeSeriesDs] = useState(graphConfig)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  const fetchData = async () => {
+    await setIsLoading(true)
+    const data = await dataFetch()
+    const schema = await schemaFetch()
+
+    // Here we are creating our DataTable
+    const fusionTable = new FusionCharts.DataStore().createDataTable(
+      data,
+      schema,
+    )
+
+    setTimeSeriesDs({
+      ...timeSeriesDs,
+      dataSource: { ...timeSeriesDs.dataSource, data: fusionTable },
+    })
+
+    await setIsLoading(false)
+  }
+
+  return !isLoading ? <ReactFC {...timeSeriesDs} /> : <div>loading</div>
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,9 @@ import dynamic from 'next/dynamic.js'
 const Column2DGraph = dynamic(() => import('../components/column2DGraph'), {
   ssr: false,
 })
+const TimeSeriesGraph = dynamic(() => import('../components/timeSeries'), {
+  ssr: false,
+})
 
 const Title = styled.h1`
   color: red;
@@ -14,6 +17,7 @@ export default function Home() {
     <div>
       <Title>My page</Title>
       <Column2DGraph />
+      <TimeSeriesGraph />
     </div>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,8 @@
 import styled from 'styled-components'
+import dynamic from 'next/dynamic.js'
+const Column2DGraph = dynamic(() => import('../components/column2DGraph'), {
+  ssr: false,
+})
 
 const Title = styled.h1`
   color: red;
@@ -6,5 +10,10 @@ const Title = styled.h1`
 `
 
 export default function Home() {
-  return <Title>My page</Title>
+  return (
+    <div>
+      <Title>My page</Title>
+      <Column2DGraph />
+    </div>
+  )
 }


### PR DESCRIPTION
## issue

#3 

## やったこと

- fusion chartsがSSR未対応なので、dynamic importを使用して、グラフを表示できるようにした
- fusion timeも使えるようにした

## 参考

https://ayon-bony.medium.com/rendering-fusioncharts-using-next-js-9630210c2854
https://github.com/AyanBhadury/nextjs-fusioncharts